### PR TITLE
[Feature] Feign 요청 시 JWT 인증 헤더 자동 전파 인터셉터 추가

### DIFF
--- a/src/main/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptor.java
@@ -4,10 +4,12 @@ import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+@Slf4j
 @Component
 public class FeignJwtInterceptor implements RequestInterceptor {
     @Override
@@ -28,6 +30,7 @@ public class FeignJwtInterceptor implements RequestInterceptor {
         }
 
         if(jwtToken != null) {
+            log.debug("Authorization 헤더에 JWT 토큰 추가: {}", jwtToken);
             requestTemplate.header("Authorization", "Bearer " + jwtToken);
         }
     }

--- a/src/main/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptor.java
+++ b/src/main/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptor.java
@@ -1,0 +1,34 @@
+package com.nhnacademy.frontend.adapter.interceptor;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class FeignJwtInterceptor implements RequestInterceptor {
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if(attributes == null) return;
+
+        HttpServletRequest request = attributes.getRequest();
+
+        String jwtToken = null;
+        if(request.getCookies() != null) {
+            for(Cookie cookie : request.getCookies()) {
+                if("accessToken".equals(cookie.getName())) {
+                    jwtToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        if(jwtToken != null) {
+            requestTemplate.header("Authorization", "Bearer " + jwtToken);
+        }
+    }
+}

--- a/src/test/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptorTest.java
+++ b/src/test/java/com/nhnacademy/frontend/adapter/interceptor/FeignJwtInterceptorTest.java
@@ -1,0 +1,86 @@
+package com.nhnacademy.frontend.adapter.interceptor;
+
+import feign.RequestTemplate;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class FeignJwtInterceptorTest {
+    @Mock
+    private RequestTemplate requestTemplate;
+
+    private final FeignJwtInterceptor interceptor = new FeignJwtInterceptor();
+
+    @Test
+    void whenRequestAttributesAreNull_thenNoHeaderAdded() {
+        try(MockedStatic<RequestContextHolder> mockedHolder = mockStatic(RequestContextHolder.class)) {
+            mockedHolder.when(RequestContextHolder::getRequestAttributes).thenReturn(null);
+            interceptor.apply(requestTemplate);
+
+            verifyNoInteractions(requestTemplate);
+        }
+    }
+
+    @Test
+    void whenNoCookies_thenNoHeaderAdded() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getCookies()).thenReturn(null);
+
+        ServletRequestAttributes attrs = new ServletRequestAttributes(mockRequest);
+        try(MockedStatic<RequestContextHolder> mockedHolder = mockStatic(RequestContextHolder.class)) {
+            mockedHolder.when(RequestContextHolder::getRequestAttributes).thenReturn(attrs);
+
+            interceptor.apply(requestTemplate);
+
+            verifyNoInteractions(requestTemplate);
+        }
+    }
+
+    @Test
+    void whenCookiesDoNotContainAccessToken_thenNoHeaderAdded() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        Cookie[] cookies = { new Cookie("other", "value"), new Cookie("foo", "bar")};
+        when(mockRequest.getCookies()).thenReturn(cookies);
+
+        ServletRequestAttributes attrs = new ServletRequestAttributes(mockRequest);
+        try(MockedStatic<RequestContextHolder> mockedHolder = mockStatic(RequestContextHolder.class)) {
+            mockedHolder.when(RequestContextHolder::getRequestAttributes).thenReturn(attrs);
+
+            interceptor.apply(requestTemplate);
+
+            verifyNoInteractions(requestTemplate);
+        }
+    }
+
+    @Test
+    void whenAccessTokenCookiePresent_thenAuthorizationHeaderAdded() {
+        String tokenValue = "abc123";
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        Cookie[] cookies = {
+                new Cookie("foo", "bar"),
+                new Cookie("accessToken", tokenValue),
+                new Cookie("other", "baz")
+        };
+        when(mockRequest.getCookies()).thenReturn(cookies);
+
+        ServletRequestAttributes attrs = new ServletRequestAttributes(mockRequest);
+        try(MockedStatic<RequestContextHolder> mockedHolder = mockStatic(RequestContextHolder.class)) {
+            mockedHolder.when(RequestContextHolder::getRequestAttributes).thenReturn(attrs);
+
+            interceptor.apply(requestTemplate);
+
+            verify(requestTemplate, times(1))
+                    .header("Authorization", "Bearer " + tokenValue);
+        }
+    }
+}


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 사용자의 쿠키에 accessToken이 존재할 경우 인증 헤더에 accessToken 내용을 세팅한 후 Feign 전송이 이루어질 수 있도록 FeignInterceptor 추가

## 🔗 관련 이슈

- #13 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
