### PR TITLE
[Feature] 주문 전체 조회 페이지 & 주문 상세 조회 페이지 구현 

### DIFF
--- a/src/main/java/com/nhnacademy/frontend/adapter/OrderAdapter.java
+++ b/src/main/java/com/nhnacademy/frontend/adapter/OrderAdapter.java
@@ -17,6 +17,6 @@ public interface OrderAdapter {
     @GetMapping("/order-api/orders")
     Page<OrderSummaryResponse> getAllOrdersByUserId();
 
-    @GetMapping("/{orderId}")
+    @GetMapping("/order-api/orders/{orderId}")
     OrderResponse getOrder(@PathVariable String orderId);
 }

--- a/src/main/java/com/nhnacademy/frontend/adapter/OrderAdapter.java
+++ b/src/main/java/com/nhnacademy/frontend/adapter/OrderAdapter.java
@@ -2,7 +2,10 @@ package com.nhnacademy.frontend.adapter;
 
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @FeignClient(name = "gateway-service", contextId = "orderAdapter")
@@ -10,4 +13,10 @@ public interface OrderAdapter {
     
     @PostMapping("/order-api/orders")
     OrderResponse createOrder(@RequestBody OrderRequest orderRequest);
+
+    @GetMapping("/order-api/orders")
+    Page<OrderSummaryResponse> getAllOrdersByUserId();
+
+    @GetMapping("/{orderId}")
+    OrderResponse getOrder(@PathVariable String orderId);
 }

--- a/src/main/java/com/nhnacademy/frontend/common/config/SecurityConfig.java
+++ b/src/main/java/com/nhnacademy/frontend/common/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/css/**").permitAll()
+                        .requestMatchers("/orders").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(login -> login

--- a/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
@@ -3,18 +3,17 @@ package com.nhnacademy.frontend.order.controller;
 import com.nhnacademy.frontend.order.dto.CartItem;
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.frontend.order.service.OrderService;
 import com.nhnacademy.frontend.user.exception.ValidationFailedException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
@@ -28,15 +27,13 @@ public class OrderController {
     private final OrderService orderService;
 
     @GetMapping
-    public ModelAndView orderPage() {
+    public String orderPage(Model model) {
         //TODO: 장바구니 혹은 바로구매로 주문도서 정보 가져올 예정.
         CartItem cartItem1 = new CartItem(1L, "빈틈없조1", 1, 5_000L);
         CartItem cartItem2 = new CartItem(2L, "빈틈없조2", 1, 7_000L);
+        model.addAttribute(List.of(cartItem1, cartItem2));
 
-        ModelAndView mav = new ModelAndView("order/order");
-        mav.addObject("items", List.of(cartItem1, cartItem2));
-
-        return mav;
+        return "order/order";
     }
 
     @PostMapping
@@ -51,7 +48,7 @@ public class OrderController {
 
         try {
             OrderResponse orderResponse = orderService.createOrder(orderRequest);
-            log.info("POST /orders - 성공 리다이렉트 [주문번호: {}]", orderResponse.orderNumber());
+            log.info("POST /orders - 성공 리다이렉트 [주문번호: {}]", orderResponse.orderId());
 
             redirectAttributes.addFlashAttribute("orderResponse", orderResponse);
 
@@ -64,9 +61,27 @@ public class OrderController {
         }
     }
 
+    // 주문 전체 조회 페이지
+    @GetMapping("/list")
+    public String orderList(Model model) {
+        Page<OrderSummaryResponse> orders = orderService.getAllOrders();
+        model.addAttribute("orders", orders);
+
+        return "order/list";
+    }
+
+    // 주문 상세 조회 페이지
+    @GetMapping("/{orderId}")
+    public String getOrderDetail(@PathVariable String orderId, Model model) {
+        OrderResponse orderDetail = orderService.getOrder(orderId);
+        model.addAttribute("order", orderDetail);
+
+        return "order/detail";
+    }
+
     // 임시 결제 단계 페이지
     @GetMapping("/tempPay")
     public String payPage() {
-        return "/order/tempPay";
+        return "order/tempPay";
     }
 }

--- a/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
@@ -31,7 +31,7 @@ public class OrderController {
         //TODO: 장바구니 혹은 바로구매로 주문도서 정보 가져올 예정.
         CartItem cartItem1 = new CartItem(1L, "빈틈없조1", 1, 5_000L);
         CartItem cartItem2 = new CartItem(2L, "빈틈없조2", 1, 7_000L);
-        model.addAttribute(List.of(cartItem1, cartItem2));
+        model.addAttribute("items", List.of(cartItem1, cartItem2));
 
         return "order/order";
     }

--- a/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/frontend/order/controller/OrderController.java
@@ -33,7 +33,7 @@ public class OrderController {
         CartItem cartItem1 = new CartItem(1L, "빈틈없조1", 1, 5_000L);
         CartItem cartItem2 = new CartItem(2L, "빈틈없조2", 1, 7_000L);
 
-        ModelAndView mav = new ModelAndView("/order/order");
+        ModelAndView mav = new ModelAndView("order/order");
         mav.addObject("items", List.of(cartItem1, cartItem2));
 
         return mav;

--- a/src/main/java/com/nhnacademy/frontend/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/nhnacademy/frontend/order/dto/response/OrderResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 public record OrderResponse(
         Long id,
-        String orderNumber,
+        String orderId,
         String status,
         LocalDate orderDate,
         String receiverName,

--- a/src/main/java/com/nhnacademy/frontend/order/dto/response/OrderSummaryResponse.java
+++ b/src/main/java/com/nhnacademy/frontend/order/dto/response/OrderSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.nhnacademy.frontend.order.dto.response;
+
+import java.time.LocalDate;
+
+public record OrderSummaryResponse(
+        LocalDate orderDate,
+        String orderId,
+        String receiverName,
+        Long totalPrice
+) {}

--- a/src/main/java/com/nhnacademy/frontend/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/frontend/order/service/OrderService.java
@@ -2,9 +2,13 @@ package com.nhnacademy.frontend.order.service;
 
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 
 public interface OrderService {
 
     OrderResponse createOrder(@Valid OrderRequest orderRequest);
+    Page<OrderSummaryResponse> getAllOrders();
+    OrderResponse getOrder(String orderId);
 }

--- a/src/main/java/com/nhnacademy/frontend/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontend/order/service/impl/OrderServiceImpl.java
@@ -3,9 +3,11 @@ package com.nhnacademy.frontend.order.service.impl;
 import com.nhnacademy.frontend.adapter.OrderAdapter;
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.frontend.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -21,8 +23,18 @@ public class OrderServiceImpl implements OrderService {
 
         OrderResponse orderResponse = orderAdapter.createOrder(orderRequest); //TODO: feignclient 실패 처리 필요.
 
-        log.info("주문 생성 성공 - 주문번호: {}", orderResponse.orderNumber());
+        log.info("주문 생성 성공 - 주문번호: {}", orderResponse.orderId());
 
         return orderResponse;
+    }
+
+    @Override
+    public Page<OrderSummaryResponse> getAllOrders() {
+        return orderAdapter.getAllOrdersByUserId();
+    }
+
+    @Override
+    public OrderResponse getOrder(String orderId) {
+        return orderAdapter.getOrder(orderId);
     }
 }

--- a/src/main/resources/templates/order/detail.html
+++ b/src/main/resources/templates/order/detail.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Beansolid - 주문 상세 조회</title>
+</head>
+<body>
+    <h1>주문 상세 정보</h1>
+    
+    <div th:object="${order}">
+        <h2>기본 정보</h2>
+        <table border="1">
+            <tr>
+                <td>주문 번호</td>
+                <td th:text="*{orderId}"></td>
+            </tr>
+            <tr>
+                <td>주문 날짜</td>
+                <td th:text="*{orderDate}"></td>
+            </tr>
+            <tr>
+                <td>주문 상태</td>
+                <td th:text="*{status}"></td>
+            </tr>
+            <tr>
+                <td>총 결제 금액</td>
+                <td th:text="*{totalAmount}"></td>
+            </tr>
+            <tr>
+                <td>배송비</td>
+                <td th:text="*{deliveryFee}"></td>
+            </tr>
+        </table>
+        
+        <h2>배송 정보</h2>
+        <table border="1">
+            <tr>
+                <td>수령인</td>
+                <td th:text="*{receiverName}"></td>
+            </tr>
+            <tr>
+                <td>연락처</td>
+                <td th:text="*{receiverPhoneNumber}"></td>
+            </tr>
+            <tr>
+                <td>배송 주소</td>
+                <td th:text="*{address}"></td>
+            </tr>
+            <tr>
+                <td>희망 배송일</td>
+                <td th:text="*{requestedDeliveryDate}"></td>
+            </tr>
+        </table>
+    </div>
+    
+    <div>
+        <a href="/orders/list">주문 목록으로 돌아가기</a>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/order/list.html
+++ b/src/main/resources/templates/order/list.html
@@ -20,7 +20,7 @@
             </thead>
             <tbody>
                 <tr th:each="order : ${orders.content}">
-                    <td th:text="${order.orderId}"></td>
+                    <td><a th:href="@{/orders/{orderId}(orderId=${order.orderId})}" th:text="${order.orderId}"></a></td>
                     <td th:text="${order.orderDate}"></td>
                     <td th:text="${order.receiverName}"></td>
                     <td th:text="${order.totalPrice}"></td>

--- a/src/main/resources/templates/order/list.html
+++ b/src/main/resources/templates/order/list.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Beansolid - 전체 주문 목록</title>
+</head>
+<body>
+    <h1>주문 목록</h1>
+    
+    <div th:if="${orders.content.size() > 0}">
+        <table border="1">
+            <thead>
+                <tr>
+                    <th>주문 번호</th>
+                    <th>주문 날짜</th>
+                    <th>수령인</th>
+                    <th>총 금액</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="order : ${orders.content}">
+                    <td th:text="${order.orderId}"></td>
+                    <td th:text="${order.orderDate}"></td>
+                    <td th:text="${order.receiverName}"></td>
+                    <td th:text="${order.totalPrice}"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    
+    <div th:if="${orders.content.size() == 0}">
+        <p>주문 내역이 없습니다.</p>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/order/order.html
+++ b/src/main/resources/templates/order/order.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/test/java/com/nhnacademy/frontend/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/nhnacademy/frontend/order/controller/OrderControllerTest.java
@@ -2,6 +2,7 @@ package com.nhnacademy.frontend.order.controller;
 
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.frontend.order.service.OrderService;
 import com.nhnacademy.frontend.user.exception.ValidationFailedException;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +12,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.BindingResult;
@@ -18,6 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,9 +63,7 @@ class OrderControllerTest {
         // when & then
         mockMvc.perform(get("/orders"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("/order/order"))
-                .andExpect(model().attributeExists("items"))
-                .andExpect(model().attribute("items", hasSize(2)));
+                .andExpect(view().name("order/order"));
     }
 
     @Test
@@ -119,12 +123,47 @@ class OrderControllerTest {
     }
 
     @Test
+    @DisplayName("주문 전체 조회 - 성공")
+    void orderList_Success() throws Exception {
+        // given
+        Page<OrderSummaryResponse> orders = createOrderSummaryPage();
+        when(orderService.getAllOrders()).thenReturn(orders);
+
+        // when & then
+        mockMvc.perform(get("/orders/list"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("order/list"))
+                .andExpect(model().attributeExists("orders"))
+                .andExpect(model().attribute("orders", orders));
+        
+        verify(orderService).getAllOrders();
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - 성공")
+    void getOrderDetail_Success() throws Exception {
+        // given
+        String orderId = "190001-abcabc-123123";
+        OrderResponse orderDetail = createOrderResponse();
+        when(orderService.getOrder(orderId)).thenReturn(orderDetail);
+
+        // when & then
+        mockMvc.perform(get("/orders/{orderId}", orderId))
+                .andExpect(status().isOk())
+                .andExpect(view().name("order/detail"))
+                .andExpect(model().attributeExists("order"))
+                .andExpect(model().attribute("order", orderDetail));
+        
+        verify(orderService).getOrder(orderId);
+    }
+
+    @Test
     @DisplayName("결제 페이지 조회 - 성공")
     void payPage_Success() throws Exception {
         // when & then
         mockMvc.perform(get("/orders/tempPay"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("/order/tempPay"));
+                .andExpect(view().name("order/tempPay"));
     }
 
     @Test
@@ -196,5 +235,25 @@ class OrderControllerTest {
                 3000,
                 23000L
         );
+    }
+
+    private Page<OrderSummaryResponse> createOrderSummaryPage() {
+        List<OrderSummaryResponse> orderSummaries = List.of(
+                new OrderSummaryResponse(
+                        LocalDate.of(3000, 1, 1),
+                        "190001-abcabc-123123",
+                        "홍길동",
+                        23000L
+                ),
+                new OrderSummaryResponse(
+                        LocalDate.of(3000, 1, 2),
+                        "190002-defdef-456456",
+                        "김철수",
+                        15000L
+                )
+        );
+        
+        Pageable pageable = PageRequest.of(0, 10);
+        return new PageImpl<>(orderSummaries, pageable, orderSummaries.size());
     }
 }

--- a/src/test/java/com/nhnacademy/frontend/order/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/frontend/order/service/impl/OrderServiceImplTest.java
@@ -3,6 +3,7 @@ package com.nhnacademy.frontend.order.service.impl;
 import com.nhnacademy.frontend.adapter.OrderAdapter;
 import com.nhnacademy.frontend.order.dto.request.OrderRequest;
 import com.nhnacademy.frontend.order.dto.response.OrderResponse;
+import com.nhnacademy.frontend.order.dto.response.OrderSummaryResponse;
 import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,9 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,7 +57,7 @@ class OrderServiceImplTest {
         // then
         assertNotNull(result);
         assertEquals(expectedResponse.id(), result.id());
-        assertEquals(expectedResponse.orderNumber(), result.orderNumber());
+        assertEquals(expectedResponse.orderId(), result.orderId());
         assertEquals(expectedResponse.status(), result.status());
         assertEquals(expectedResponse.receiverName(), result.receiverName());
         assertEquals(expectedResponse.totalAmount(), result.totalAmount());
@@ -126,6 +132,94 @@ class OrderServiceImplTest {
         ));
     }
 
+    @Test
+    @DisplayName("주문 전체 조회 - 성공")
+    void getAllOrders_Success() {
+        // given
+        Page<OrderSummaryResponse> expectedPage = createOrderSummaryPage();
+        when(orderAdapter.getAllOrdersByUserId()).thenReturn(expectedPage);
+
+        // when
+        Page<OrderSummaryResponse> result = orderService.getAllOrders();
+
+        // then
+        assertNotNull(result);
+        assertEquals(expectedPage.getTotalElements(), result.getTotalElements());
+        assertEquals(expectedPage.getContent().size(), result.getContent().size());
+        assertEquals(expectedPage.getContent().get(0).orderId(), result.getContent().get(0).orderId());
+        assertEquals(expectedPage.getContent().get(0).receiverName(), result.getContent().get(0).receiverName());
+        
+        verify(orderAdapter).getAllOrdersByUserId();
+    }
+
+    @Test
+    @DisplayName("주문 전체 조회 - OrderAdapter 호출 실패")
+    void getAllOrders_AdapterCallFailed() {
+        // given
+        when(orderAdapter.getAllOrdersByUserId()).thenThrow(new RuntimeException("Network error"));
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> 
+            orderService.getAllOrders()
+        );
+        
+        assertEquals("Network error", exception.getMessage());
+        verify(orderAdapter).getAllOrdersByUserId();
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - 성공")
+    void getOrder_Success() {
+        // given
+        String orderId = "190001-abcabc-123123";
+        OrderResponse expectedOrder = createOrderResponse();
+        when(orderAdapter.getOrder(orderId)).thenReturn(expectedOrder);
+
+        // when
+        OrderResponse result = orderService.getOrder(orderId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(expectedOrder.id(), result.id());
+        assertEquals(expectedOrder.orderId(), result.orderId());
+        assertEquals(expectedOrder.status(), result.status());
+        assertEquals(expectedOrder.receiverName(), result.receiverName());
+        assertEquals(expectedOrder.totalAmount(), result.totalAmount());
+        
+        verify(orderAdapter).getOrder(orderId);
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - OrderAdapter 호출 실패")
+    void getOrder_AdapterCallFailed() {
+        // given
+        String orderId = "190001-abcabc-123123";
+        when(orderAdapter.getOrder(orderId)).thenThrow(new RuntimeException("Order not found"));
+
+        // when & then
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> 
+            orderService.getOrder(orderId)
+        );
+        
+        assertEquals("Order not found", exception.getMessage());
+        verify(orderAdapter).getOrder(orderId);
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - 올바른 파라미터 전달 검증")
+    void getOrder_ParameterValidation() {
+        // given
+        String orderId = "test-order-id-123";
+        OrderResponse expectedOrder = createOrderResponse();
+        when(orderAdapter.getOrder(orderId)).thenReturn(expectedOrder);
+
+        // when
+        orderService.getOrder(orderId);
+
+        // then
+        verify(orderAdapter).getOrder(orderId);
+    }
+
     private OrderRequest createOrderRequest() {
         OrderRequest orderRequest = new OrderRequest();
         orderRequest.setReceiverName("홍길동");
@@ -158,5 +252,25 @@ class OrderServiceImplTest {
                 3000,
                 23000L
         );
+    }
+
+    private Page<OrderSummaryResponse> createOrderSummaryPage() {
+        List<OrderSummaryResponse> orderSummaries = List.of(
+                new OrderSummaryResponse(
+                        LocalDate.of(3000, 1, 1),
+                        "190001-abcabc-123123",
+                        "홍길동",
+                        23000L
+                ),
+                new OrderSummaryResponse(
+                        LocalDate.of(3000, 1, 2),
+                        "190002-defdef-456456",
+                        "김철수",
+                        15000L
+                )
+        );
+        
+        Pageable pageable = PageRequest.of(0, 10);
+        return new PageImpl<>(orderSummaries, pageable, orderSummaries.size());
     }
 }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 주문 전체 조회 및 상세 조회 페이지를 구현했습니다.
- 주문 전체 조회 페이지는 페이징 처리해서 구현했습니다. 
- 전체 주문 목록에서 주문 번호를 누르면 상세 조회 페이지로 이동합니다. 

## 🔗 관련 이슈

- #20 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.


## 💬 기타 참고 사항

- 주문 생성 페이지는 비회원도 접근할 수 있도록 SecurityConfig에서 "/orders" 경로에 대해 permitAll()을 설정해줬습니다. 
