### PR TITLE
feat(frontend) : 내정보를 볼 수 있는 페이지 추가, 이 곳에서 회원정보를 수정하는 페이지가기, 비밀번호 수정하…

### DIFF
--- a/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
+++ b/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
@@ -15,6 +15,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.Objects;
+
 @Controller
 @RequestMapping("/mypage")
 @RequiredArgsConstructor
@@ -62,11 +64,29 @@ public class MypageController {
         return "mypage/edit";
     }
 
-    @PutMapping("/edit")
-    @ResponseBody
-    public ResponseEntity<Void> mypageEdit(@RequestBody UserUpdateRequestDto userUpdateRequestDto) {
-        mypageService.updatePersonalInformation(userUpdateRequestDto);
-        return ResponseEntity.ok().build();
+    @PostMapping("/edit")
+    public String editMyPage(@RequestParam String password,
+                             @RequestParam(required = false) String userPassword,
+                             @RequestParam(required = false) String userPasswordConfirm,
+                             @ModelAttribute UserUpdateRequestDto request,
+                             RedirectAttributes redirectAttributes,
+                             @RequestHeader(value = "Referer", required = false) String referer) {
+        if (userPassword != null || userPasswordConfirm != null) {
+            if (!Objects.equals(userPassword, userPasswordConfirm)) {
+                redirectAttributes.addFlashAttribute("error", "수정할 비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+                return "redirect:" + (referer != null ? referer : "/mypage/edit");
+            }
+        }
+        boolean isPasswordCorrect = mypageService.updatePersonalInformationWithPassword(password);
+
+        if (!isPasswordCorrect) {
+            redirectAttributes.addFlashAttribute("error", "비밀번호가 일치하지 않습니다.");
+            return "redirect:" + (referer != null ? referer : "/mypage/myinfo");
+        }
+
+        mypageService.updatePersonalInformation(request);
+        redirectAttributes.addFlashAttribute("message", "정보가 성공적으로 수정되었습니다.");
+        return "redirect:/mypage/myinfo";
     }
 
     @GetMapping("/address")
@@ -96,5 +116,19 @@ public class MypageController {
     @GetMapping("/address/register")
     public String mypageAddressRegisterForm() {
         return "mypage/address_register";
+    }
+
+    @GetMapping("/myinfo")
+    public String mypageInfo(Model model) {
+        ResponseUser user = mypageService.getMyInfo();
+        model.addAttribute("user", user);
+        return "mypage/myinfo";
+    }
+
+    @GetMapping("/editpassword")
+    public String mypageEditPasswordForm(Model model) {
+        ResponseUser user = mypageService.getMyInfo();
+        model.addAttribute("user", user);
+        return "mypage/editpassword";
     }
 }

--- a/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
+++ b/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
@@ -8,6 +8,7 @@ import com.nhnacademy.frontend.mypage.domain.request.UserUpdateRequestDto;
 import com.nhnacademy.frontend.mypage.service.MypageService;
 import feign.FeignException;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -119,7 +120,15 @@ public class MypageController {
     }
 
     @GetMapping("/myinfo")
-    public String mypageInfo(Model model) {
+    public String mypageInfo(HttpSession session, Model model) {
+        Boolean verified = (Boolean) session.getAttribute("mypage_verified");
+        if (verified == null || !verified) {
+            return "redirect:/mypage/verify";
+        }
+
+        // 1회성 인증으로 사용 후 플래그 제거
+        session.removeAttribute("mypage_verified");
+
         ResponseUser user = mypageService.getMyInfo();
         model.addAttribute("user", user);
         return "mypage/myinfo";
@@ -130,5 +139,23 @@ public class MypageController {
         ResponseUser user = mypageService.getMyInfo();
         model.addAttribute("user", user);
         return "mypage/editpassword";
+    }
+
+    @PostMapping("/verify")
+    public String verifyPassword(@RequestParam String password,
+                                 HttpSession session,
+                                 RedirectAttributes redirectAttributes) {
+        if (!mypageService.updatePersonalInformationWithPassword(password)) {
+            redirectAttributes.addFlashAttribute("error", "비밀번호가 일치하지 않습니다.");
+            return "redirect:/mypage/verify";
+        }
+        // 인증 성공 시 세션에 인증 플래그 설정
+        session.setAttribute("mypage_verified", true);
+        return "redirect:/mypage/myinfo";
+    }
+
+    @GetMapping("/verify")
+    public String mypageVerifyForm() {
+        return "mypage/verify";
     }
 }

--- a/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
+++ b/src/main/java/com/nhnacademy/frontend/mypage/controller/MypageController.java
@@ -121,9 +121,13 @@ public class MypageController {
 
     @GetMapping("/myinfo")
     public String mypageInfo(HttpSession session, Model model) {
-        Boolean verified = (Boolean) session.getAttribute("mypage_verified");
-        if (verified == null || !verified) {
-            return "redirect:/mypage/verify";
+        String userType = (String) model.getAttribute("userType");
+
+        if("LOCAL".equals(userType)) {
+            Boolean verified = (Boolean) session.getAttribute("mypage_verified");
+            if (verified == null || !verified) {
+                return "redirect:/mypage/verify";
+            }
         }
 
         // 1회성 인증으로 사용 후 플래그 제거

--- a/src/main/java/com/nhnacademy/frontend/mypage/service/MypageService.java
+++ b/src/main/java/com/nhnacademy/frontend/mypage/service/MypageService.java
@@ -22,4 +22,6 @@ public interface MypageService {
 
     void addAddress(AddressCreateRequest address);
 
+    boolean updatePersonalInformationWithPassword(String password);
+
 }

--- a/src/main/java/com/nhnacademy/frontend/mypage/service/MypageServiceImpl.java
+++ b/src/main/java/com/nhnacademy/frontend/mypage/service/MypageServiceImpl.java
@@ -73,4 +73,14 @@ public class MypageServiceImpl implements MypageService {
     public void addAddress(AddressCreateRequest address) {
         userAdapter.addAddress(address);
     }
+
+    @Override
+    public boolean updatePersonalInformationWithPassword(String password) {
+        try {
+            PasswordVerificationRequestDto verificationRequest = new PasswordVerificationRequestDto(password);
+            return authAdapter.verifyPassword(verificationRequest);
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/src/main/resources/templates/mypage/edit.html
+++ b/src/main/resources/templates/mypage/edit.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="">
 <head>
     <meta charset="UTF-8">
     <title>개인정보 수정</title>
@@ -7,7 +7,15 @@
 </head>
 <body class="container py-5">
 <h2 class="mb-4">개인정보 수정</h2>
-<form th:action="@{/mypage/edit}" method="post">
+
+
+<!-- 개인정보 수정 form -->
+<form id="editForm" method="post" th:action="@{/mypage/edit}">
+    <div th:if="${userType == 'LOCAL'}" class="mb-3">
+        <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
+        <label for="password" class="form-label">현재 비밀번호</label>
+        <input type="password" class="form-control" id="password" name="password" placeholder="현재 비밀번호 입력" required />
+    </div>
     <div class="mb-3">
         <label for="userName" class="form-label">이름</label>
         <input type="text" class="form-control" id="userName" name="userName" th:value="${user.userName}" required>
@@ -26,47 +34,6 @@
     </div>
     <button type="submit" id="submitBtn" class="btn btn-primary">수정하기</button>
 </form>
+
 </body>
 </html>
-
-<script>
-    document.getElementById('submitBtn').addEventListener('click', function (event) {
-        event.preventDefault();
-
-        const form = document.querySelector('form');
-        if (!form.checkValidity()) {
-            form.reportValidity();
-            return;
-        }
-
-        const data = {
-            userName: document.getElementById('userName').value,
-            userPhoneNumber: document.getElementById('userPhoneNumber').value,
-            userEmail: document.getElementById('userEmail').value,
-            userBirth: document.getElementById('userBirth').value
-        };
-
-        fetch('/mypage/edit', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(data)
-        })
-            .then(async response => {
-                if (response.ok) {
-                    alert('개인정보 수정 완료!');
-                    window.location.href = '/mypage';
-                } else {
-                    const errorData = await response.json();
-                    alert(`수정 실패: ${errorData.message || '알 수 없는 오류'}`);
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('수정 요청 중 네트워크 오류가 발생했습니다.');
-
-            });
-
-    });
-</script>

--- a/src/main/resources/templates/mypage/editpassword.html
+++ b/src/main/resources/templates/mypage/editpassword.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 변경</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+<h2 class="mb-4">비밀번호 변경</h2>
+<form th:action="@{/mypage/edit}" method="post">
+    <div class="mb-3">
+        <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
+        <label for="password" class="form-label">현재 비밀번호</label>
+        <input type="password" class="form-control" id="password" name="password" placeholder="현재 비밀번호 입력" required>
+    </div>
+    <div class="mb-3">
+        <label for="userPassword" class="form-label">수정할 비밀번호</label>
+        <input type="password" class="form-control" id="userPassword" name="userPassword" placeholder="수정할 비밀번호 입력" required>
+    </div>
+    <div class="mb-3">
+        <label for="userPasswordConfirm" class="form-label">수정할 비밀번호 확인</label>
+        <input type="password" class="form-control" id="userPasswordConfirm" name="userPasswordConfirm" placeholder="수정할 비밀번호 확인" required>
+    </div>
+    <div class="mb-3">
+        <input type="hidden" class="form-control" id="userName" name="userName" th:value="${user.userName}" required>
+    </div>
+    <div class="mb-3">
+        <input type="hidden" class="form-control" id="userPhoneNumber" name="userPhoneNumber" th:value="${user.userPhoneNumber}" required>
+    </div>
+    <div class="mb-3">
+        <input type="hidden" class="form-control" id="userEmail" name="userEmail" th:value="${user.userEmail}" required>
+    </div>
+    <div class="mb-3">
+        <input type="hidden" class="form-control" id="userBirth" name="userBirth" th:value="${user.userBirth}" required>
+    </div>
+    <button type="submit" id="submitBtn" class="btn btn-primary">변경하기</button>
+</form>
+</body>
+</html>
+
+<script>
+    document.getElementById('submitBtn').addEventListener('click', function(event) {
+        const password = document.getElementById('userPassword').value;
+        const confirmPassword = document.getElementById('userPasswordConfirm').value;
+
+        if (password !== confirmPassword) {
+            event.preventDefault();
+            alert('수정할 비밀번호와 비밀번호 확인이 일치하지 않습니다.');
+        }
+    });
+</script>

--- a/src/main/resources/templates/mypage/form.html
+++ b/src/main/resources/templates/mypage/form.html
@@ -15,7 +15,7 @@
         <a href="/mypage/grade">회원등급 확인</a>
     </li>
     <li>
-        <a href="/mypage/edit">회원정보 수정</a>
+        <a href="/mypage/edit">회원정보 수정(테스트용임 추후 삭제필요)</a>
     </li>
     <li>
         <a href="/mypage/myinfo">내 정보</a>

--- a/src/main/resources/templates/mypage/form.html
+++ b/src/main/resources/templates/mypage/form.html
@@ -17,6 +17,9 @@
     <li>
         <a href="/mypage/edit">회원정보 수정</a>
     </li>
+    <li>
+        <a href="/mypage/myinfo">내 정보</a>
+    </li>
 </ul>
 
 <!-- 탈퇴 버튼 -->

--- a/src/main/resources/templates/mypage/myinfo.html
+++ b/src/main/resources/templates/mypage/myinfo.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>내 정보</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 30px;
+        }
+        .info-container {
+            max-width: 500px;
+            margin: auto;
+        }
+        .info-item {
+            margin-bottom: 15px;
+        }
+        .label {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+<div th:if="${message}" class="alert alert-success" th:text="${message}"></div>
+<div class="info-container">
+    <h1>내 정보</h1>
+
+    <div class="info-item">
+        <span class="label">아이디:</span>
+        <span th:text="${user.userId}">userId</span>
+    </div>
+    <div class="info-item">
+        <span class="label">이름:</span>
+        <span th:text="${user.userName}">userName</span>
+    </div>
+    <div class="info-item">
+        <span class="label">전화번호:</span>
+        <span th:text="${user.userPhoneNumber}">userPhoneNumber</span>
+    </div>
+    <div class="info-item">
+        <span class="label">이메일:</span>
+        <span th:text="${user.userEmail}">userEmail</span>
+    </div>
+    <div class="info-item">
+        <span class="label">생년월일:</span>
+        <span th:text="${user.userBirth}">userBirth</span>
+    </div>
+    <div class="info-item">
+        <span class="label">포인트:</span>
+        <span th:text="${user.userPoint}">userPoint</span>
+    </div>
+    <div class="info-item">
+        <span class="label">마지막 로그인:</span>
+        <span th:text="${#strings.replace(user.lastLoginAt, 'T', ' ')}">lastLoginAt</span>
+    </div>
+    <div class="info-item">
+        <span class="label">회원 등급:</span>
+        <span th:text="${user.userGradeName}">userGradeName</span>
+    </div>
+</div>
+<div class="info-item">
+    <button onclick="location.href='/mypage/edit'">회원정보 수정</button>
+    <button th:if="${userType == 'LOCAL'}" onclick="location.href='/mypage/editpassword'">비밀번호 변경</button>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/mypage/verify.html
+++ b/src/main/resources/templates/mypage/verify.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 인증</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+    <h2 class="mb-4 text-center">비밀번호 인증</h2>
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <form th:action="@{/mypage/verify}" method="post">
+                <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">비밀번호를 입력하세요</label>
+                    <input type="password" class="form-control" id="password" name="password" placeholder="비밀번호" required>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">확인</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
…는 페이지 가기 추가, Oauth2계정일시 비밀번호 인증 불필요하게 함(계정이 없어 테스트는 못해봄) Fixes#39

<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 내정보보기 페이지 추가, 정보수정 시 비밀번호 인증기능 추가, 비밀번호 수정기능 추가

## 🔗 관련 이슈

- #39 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [ ] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
